### PR TITLE
Add script for building ROM image using Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+out.lst
+res/resources.h
+**/*.bin
+**/*.o
+symbol.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:stretch
+
+ARG MARSDEV_REVISION
+
+RUN apt-get update --quiet=2
+RUN apt-get install \
+        --assume-yes \
+        --no-install-recommends \
+        --quiet=2 \
+        build-essential \
+        libtool \
+        autoconf \
+        automake \
+        autopoint \
+        gettext \
+        wget \
+        texinfo \
+        libpng-dev \
+        openjdk-8-jre-headless \
+        git \
+        libboost-all-dev
+
+RUN git clone \
+        --quiet \
+        --branch ${MARSDEV_REVISION} \
+        --depth 1 \
+        https://github.com/andwn/marsdev.git
+RUN cd /marsdev && make
+
+WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Feel free to contribute a Windows build/Makefile, but I don't have the means rig
 1. Set up [marsdev](https://github.com/andwn/marsdev)
 2. Just clone & make!
 
+Alternatively, you can build on other platforms (e.g. OS X) using Docker:
+
+1. Install [Docker](https://www.docker.com/)
+1. Run:
+ 
+        $ ./build-rom.sh
+                
+1. The built ROM is named `ym2017-${GIT_REVISION}.bin`
+
 If you have a YM2017 cart, it is reflashable with Krikzz flasher. So if you want
 to play with the LEDs by making your own ROMs you are free to do so.
 

--- a/build-rom.sh
+++ b/build-rom.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+IMAGE_TAG="andwn/ym2017:latest"
+IMAGE_NAME="ym2017"
+MARSDEV_REVISION="2017.09.12"
+
+rm ym2017*.bin
+docker build \
+    --tag ${IMAGE_TAG} \
+    --build-arg MARSDEV_REVISION=${MARSDEV_REVISION} \
+    .
+docker run \
+    --volume "${PWD}:/src" \
+    --rm \
+    --name ${IMAGE_NAME} \
+    ${IMAGE_TAG} \
+    /bin/bash -c "make clean all"
+GIT_REVISION=$(docker run \
+    --volume "${PWD}:/src" \
+    --rm \
+    --name ${IMAGE_NAME} \
+    ${IMAGE_TAG} \
+    /bin/bash -c "git rev-parse HEAD")
+mv ym2017.bin ym2017-${GIT_REVISION}.bin


### PR DESCRIPTION
This pull request adds a script for building YM2017 ROM images in a [Docker](https://www.docker.com/) container.

This allows for building the ROM in an isolated build environment and/or on platforms other than GNU/Linux (tested on OS X 10.11.6 and Docker 17.10.0-ce).