### PR TITLE
fixing rescomp - Now a Java App

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OBJC = $(MARSBIN)/m68k-elf-objcopy
 
 ASMZ80  = $(TOOLSBIN)/sjasm
 BINTOS  = $(TOOLSBIN)/bintos
-RESCOMP = $(TOOLSBIN)/rescomp
+RESCOMP = java -jar $(TOOLSBIN)/rescomp.jar
 XGMTOOL = $(TOOLSBIN)/xgmtool
 WAVTORAW= $(TOOLSBIN)/wavtoraw
 


### PR DESCRIPTION
Seems SGDK has made rescomp into a java app. So now we must modify the Makefile accordingly.